### PR TITLE
Minor tweaks I made while setting up the site

### DIFF
--- a/BuildMonitor/Content/Site.css
+++ b/BuildMonitor/Content/Site.css
@@ -56,6 +56,9 @@ html * {
 
 /* Build monitor --------------------------------------------------------------------------------- */
 
+.projectRow {
+    clear:both;
+}
 .projectTitle {
 	color: #777;
 	margin-top: -12px;

--- a/BuildMonitor/Helpers/CustomBuildMonitorModelHandler.cs
+++ b/BuildMonitor/Helpers/CustomBuildMonitorModelHandler.cs
@@ -64,8 +64,8 @@ namespace BuildMonitor.Helpers
 				var buildStatusJsonString = RequestHelper.GetJson(url);
 				buildStatusJson = JsonConvert.DeserializeObject<dynamic>(buildStatusJsonString ?? string.Empty);
 
-				build.Branch = buildStatusJson.branchName ?? "default";
-				build.Status = GetBuildStatusForRunningBuild(build.Id);
+                build.Branch = (buildStatusJson != null) ? (buildStatusJson.branchName ?? "default") : "unknown";
+                build.Status = GetBuildStatusForRunningBuild(build.Id);
 
 				if (build.Status == BuildStatus.Running)
 				{

--- a/BuildMonitor/Helpers/DefaultBuildMonitorModelHandler.cs
+++ b/BuildMonitor/Helpers/DefaultBuildMonitorModelHandler.cs
@@ -47,8 +47,8 @@ namespace BuildMonitor.Helpers
 				var buildStatusJsonString = RequestHelper.GetJson(url);
 				buildStatusJson = JsonConvert.DeserializeObject<dynamic>(buildStatusJsonString ?? string.Empty);
 
-				build.Branch = buildStatusJson.branchName ?? "default";
-				build.Status = GetBuildStatusForRunningBuild(build.Id);
+                build.Branch = (buildStatusJson != null) ? (buildStatusJson.branchName ?? "default") : "unknown";
+                build.Status = GetBuildStatusForRunningBuild(build.Id);
 
 				if (build.Status == BuildStatus.Running)
 				{

--- a/BuildMonitor/Views/Home/Index.cshtml
+++ b/BuildMonitor/Views/Home/Index.cshtml
@@ -10,7 +10,7 @@
 		continue;
 	}
 
-	<div>
+	<div class="projectRow">
 		<h3 class="projectTitle">▪▪▪ @project.Name ▪▪▪</h3>
 		<div class="row">
 			@foreach (var build in project.Builds)


### PR DESCRIPTION
I noticed a few things that hung me up while I was setting up this project and I wanted to contribute the (very minor) changes I made back to the base repo.  Awesome work by the way, the best TC build monitor I've used so far!

Added an additional check to Build Handlers for build configs that do not yet have associated branches.  It is an edge case, but without branches the page would not load correctly.

Additionally I fixed a bug in Chrome where the project row titles were not correctly floating to the left after the first row.  I added a CSS class and a clear:both to correct the issue.
