### PR TITLE
Fix title alignment, show name and status description.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ npm-debug.log
 *.ipr
 *.iws
 /.project
+/packages

--- a/BuildMonitor/BuildMonitor.csproj
+++ b/BuildMonitor/BuildMonitor.csproj
@@ -213,16 +213,7 @@
     <VisualStudio>
       <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
         <WebProjectProperties>
-          <UseIIS>False</UseIIS>
-          <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>50316</DevelopmentServerPort>
-          <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:64568/</IISUrl>
-          <NTLMAuthentication>False</NTLMAuthentication>
-          <UseCustomServer>False</UseCustomServer>
-          <CustomServerUrl>
-          </CustomServerUrl>
-          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+          <SaveServerSettingsInUserFile>True</SaveServerSettingsInUserFile>
         </WebProjectProperties>
       </FlavorProperties>
     </VisualStudio>

--- a/BuildMonitor/Content/Site.css
+++ b/BuildMonitor/Content/Site.css
@@ -59,6 +59,7 @@ html * {
 .projectTitle {
 	color: #777;
 	margin-top: -12px;
+	display: inline-block;
 }
 
 .buildTitle {

--- a/BuildMonitor/Helpers/DefaultBuildMonitorModelHandler.cs
+++ b/BuildMonitor/Helpers/DefaultBuildMonitorModelHandler.cs
@@ -58,6 +58,7 @@ namespace BuildMonitor.Helpers
 				build.UpdatedBy = GetUpdatedBy();
 				build.LastRunText = GetLastRunText();
 				build.IsQueued = IsBuildQueued(build.Id);
+				build.StatusDescription = (string)buildStatusJson.statusText;
 
 				if (build.Status == BuildStatus.Running)
 				{
@@ -100,23 +101,30 @@ namespace BuildMonitor.Helpers
 		{
 			try
 			{
-				if ((string)buildStatusJson.triggered.type == "user")
+				var triggerType = (string)buildStatusJson.triggered.type;
+                if (triggerType == "user")
 				{
 					return (string)buildStatusJson.triggered.user.name;
 				}
-				else if ((string)buildStatusJson.triggered.type == "unknown")
+
+				if (triggerType == "vcs" && buildStatusJson.lastChanges != null)
+				{
+					var result = RequestHelper.GetJson(teamCityUrl + buildStatusJson.lastChanges.change[0].href);
+					var change = JsonConvert.DeserializeObject<dynamic>(result);
+
+					return (string)change.user.name;
+				}
+
+				if (triggerType == "unknown")
 				{
 					return "TeamCity";
-				}
-				else
-				{
-					return "Unknown";
 				}
 			}
 			catch
 			{
-				return "Unknown";
 			}
+
+			return "Unknown";
 		}
 	}
 }

--- a/BuildMonitor/Models/Home/Build.cs
+++ b/BuildMonitor/Models/Home/Build.cs
@@ -10,6 +10,8 @@ namespace BuildMonitor.Models.Home
 		public string UpdatedBy { get; set; }
 		public string LastRunText { get; set; }
 		public bool IsQueued { get; set; }
+		public string StatusDescription { get; set; }
+
 
 		public string StatusText
 		{

--- a/BuildMonitor/Views/Shared/_BuildItem.cshtml
+++ b/BuildMonitor/Views/Shared/_BuildItem.cshtml
@@ -4,6 +4,7 @@
 	<div class="well">
 		<h4 class="buildTitle text-cutoff">@Model.Name</h4>
 		<h2 class="status-@Model.Status text-cutoff">@Model.StatusText</h2>
+		<p class="buildInfo text-cutoff">@Model.StatusDescription</p>
 		<p class="buildInfoBranch text-cutoff">
 			Branch <span class="buildInfoHighlight">@Model.Branch</span>
 			@if (!string.IsNullOrWhiteSpace(Model.Progress))


### PR DESCRIPTION
- Title should align left all the way in all major browsers.
- Showing name of user with last changes _(instead of Unknown)_ if build triggered by VCS.
- Showing build/test status description.
  ![tests](https://cloud.githubusercontent.com/assets/1763448/10952385/b9cac57c-8342-11e5-86e5-66830f54fbf4.PNG)
  (I guess this could be made configurable.)
- Ignore NuGet packages from source, since they will be fetched and added on first build.
