### PR TITLE
FIXED: Handle jobs that has no builds yet.

### DIFF
--- a/BuildMonitor/Helpers/DefaultBuildMonitorModelHandler.cs
+++ b/BuildMonitor/Helpers/DefaultBuildMonitorModelHandler.cs
@@ -47,6 +47,11 @@ namespace BuildMonitor.Helpers
 				var buildStatusJsonString = RequestHelper.GetJson(url);
 				buildStatusJson = JsonConvert.DeserializeObject<dynamic>(buildStatusJsonString ?? string.Empty);
 
+                if (buildStatusJson == null)
+                {
+                    continue; // This job has no builds yet.
+                }
+
                 build.Branch = (buildStatusJson != null) ? (buildStatusJson.branchName ?? "default") : "unknown";
                 build.Status = GetBuildStatusForRunningBuild(build.Id);
 


### PR DESCRIPTION
This PR fixes a runtime error that occurs when a build configuration has no builds yet.
