### PR TITLE
Moved sample settings to separate file

### DIFF
--- a/BuildMonitor/App_Data/Settings.example.xml
+++ b/BuildMonitor/App_Data/Settings.example.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Settings>
+  <Groups>
+    <Group name="Backend">
+      <Jobs>
+        <Job id="TeamCity_Job_Id_1" />
+        <Job id="TeamCity_Job_Id_2" />
+        <Job id="TeamCity_Job_Id_3" />
+        <Job id="TeamCity_Job_Id_4" />
+      </Jobs>
+    </Group>
+    <Group name="Frontend">
+      <Jobs>
+        <Job id="TeamCity_Job_Id_5" />
+        <Job id="TeamCity_Job_Id_6" />
+        <Job id="TeamCity_Job_Id_7" />
+        <Job id="TeamCity_Job_Id_8" />
+      </Jobs>
+    </Group>
+    <Group name="Tests">
+      <Jobs>
+        <Job id="TeamCity_Job_Id_9" />
+        <Job id="TeamCity_Job_Id_10" />
+      </Jobs>
+    </Group>
+  </Groups>
+</Settings>

--- a/BuildMonitor/App_Data/Settings.xml
+++ b/BuildMonitor/App_Data/Settings.xml
@@ -1,28 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Settings>
-	<Groups>
-		<!-- Example xml structure for custom jobs, you can create as many groups with jobs as you want here -->
-		<Group name="Backend">
-			<Jobs>
-				<Job id="TeamCity_Job_Id_1" />
-				<Job id="TeamCity_Job_Id_2" />
-				<Job id="TeamCity_Job_Id_3" />
-				<Job id="TeamCity_Job_Id_4" />
-			</Jobs>
-		</Group>
-		<Group name="Frontend">
-			<Jobs>
-				<Job id="TeamCity_Job_Id_5" />
-				<Job id="TeamCity_Job_Id_6" />
-				<Job id="TeamCity_Job_Id_7" />
-				<Job id="TeamCity_Job_Id_8" />
-			</Jobs>
-		</Group>
-		<Group name="Tests">
-			<Jobs>
-				<Job id="TeamCity_Job_Id_9" />
-				<Job id="TeamCity_Job_Id_10" />
-			</Jobs>
-		</Group>
-	</Groups>
+  <Groups>
+    <!-- TODO: Add your groups and jobs here, if you use the CustomBuildMonitorModelHandler. See the Settings.example.xml file for schema and samples. -->
+  </Groups>
 </Settings>

--- a/BuildMonitor/BuildMonitor.csproj
+++ b/BuildMonitor/BuildMonitor.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="App_Data\Settings.example.xml" />
     <Content Include="App_Data\Settings.xml" />
     <Content Include="Content\bootstrap.css" />
     <Content Include="favicon.ico" />


### PR DESCRIPTION
The samples from the Settings.xml is moved to a separate file so first run won't break and simplify development by avoiding committing custom settings to Git.
